### PR TITLE
Improve README and local setup guidance

### DIFF
--- a/DEPLOYMENT_NOTES.md
+++ b/DEPLOYMENT_NOTES.md
@@ -1,0 +1,107 @@
+# Foundation-1 Deployment Notes
+
+If you're new to ML infrastructure, the phrase you usually want is one of these:
+
+- model hosting
+- inference server
+- inference endpoint
+- GPU inference deployment
+
+For this model, the simplest mental model is:
+
+1. Load the model once onto a GPU.
+2. Expose an HTTP API.
+3. Send prompts to that API.
+4. Return generated audio.
+
+The included API server lives at `deploy/api_server.py` and exposes:
+
+- `GET /health`
+- `POST /generate`
+
+Example local run:
+
+```bash
+source .venv/bin/activate
+uvicorn deploy.api_server:app --host 0.0.0.0 --port 8000
+```
+
+Example request:
+
+```bash
+curl -X POST http://127.0.0.1:8000/generate \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "Bass, Wavetable Bass, Acid, 4 Bars, 140 BPM, F minor",
+    "seconds_total": 8,
+    "steps": 12,
+    "cfg_scale": 7.0,
+    "seed": 42
+  }' \
+  --output foundation1-api.wav
+```
+
+## Which Deployment Option Fits What
+
+### 1. Hugging Face Spaces
+
+Best when you want a public demo UI.
+
+- Spaces can host Gradio apps and Docker apps.
+- Spaces can be upgraded to GPU hardware.
+- Good for sharing, testing prompts, and showing the model to people.
+- Not my first choice for a production API.
+
+### 2. Hugging Face Inference Endpoints
+
+Best when you want a managed API and are okay paying for a hosted endpoint.
+
+- Hugging Face supports custom Docker containers for models with custom inference logic.
+- Their custom container guide explicitly recommends exposing `/health` and `/generate`.
+- The selected model repository is mounted at `/repository` inside the container.
+
+This is the cleanest managed option if you want Hugging Face to own most of the hosting layer.
+
+### 3. Modal
+
+Best when you want a Python-first deployment workflow.
+
+- Modal lets you deploy Python functions and web endpoints.
+- You choose a GPU in code, for example `gpu="A10G"` or `gpu="L40S"`.
+- Good ergonomics for developers and fast iteration.
+
+This is usually the easiest "real deployment" for a solo developer who wants less Docker pain.
+
+### 4. RunPod Serverless
+
+Best when you want flexible GPU hosting and don't mind Docker.
+
+- RunPod Serverless scales from zero and bills only for active compute time.
+- Queue-based endpoints use a handler function.
+- Load-balancing endpoints let you run your own HTTP server, including FastAPI.
+
+For this project, a FastAPI container is a good fit for a RunPod load-balancing endpoint.
+
+## My Recommendation
+
+If your goal is learning:
+
+1. Run locally first.
+2. Deploy the Gradio UI to a Hugging Face Space if you want a shareable demo.
+3. Deploy the FastAPI app to Modal or RunPod when you want a real API.
+
+If your goal is shipping an app quickly:
+
+- Modal is the easiest developer experience.
+- RunPod is attractive if you want more direct infrastructure control.
+- Hugging Face Inference Endpoints is the most managed path if you want to stay close to the Hub.
+
+## Provider Notes
+
+The current official docs I used for this recommendation:
+
+- Hugging Face custom containers: https://huggingface.co/docs/inference-endpoints/engines/custom_container
+- Hugging Face Spaces overview: https://huggingface.co/docs/hub/en/spaces-overview
+- Modal GPU guide: https://modal.com/docs/guide/gpu
+- RunPod Serverless overview: https://docs.runpod.io/serverless/overview
+- RunPod endpoints overview: https://docs.runpod.io/serverless/endpoints/overview

--- a/LOCAL_MAC_SETUP.md
+++ b/LOCAL_MAC_SETUP.md
@@ -1,0 +1,93 @@
+# Foundation-1 On macOS
+
+This repo now has a verified local path for Apple Silicon Macs.
+
+What was tested:
+
+- Machine: Apple Silicon MacBook Pro
+- Runtime: `python3.10`
+- Backend: PyTorch `mps`
+- Model: `RoyalCities/Foundation-1`
+- Proof: local Gradio app booted and a headless smoke-test WAV was generated
+
+## Quick Start
+
+From the repo root:
+
+```bash
+chmod +x scripts/setup_foundation1_macos.sh
+./scripts/setup_foundation1_macos.sh
+```
+
+Then either:
+
+```bash
+source .venv/bin/activate
+python run_gradio.py
+```
+
+Or generate a short sample from the terminal:
+
+```bash
+source .venv/bin/activate
+python scripts/generate_foundation1.py
+```
+
+The smoke-test output goes to `generations/foundation1-smoketest.wav`.
+
+## Why The Setup Looks A Bit Weird
+
+The upstream README is mostly right, but two macOS compatibility fixes were needed during verification:
+
+- `setuptools<81`: older `librosa` still imports `pkg_resources`
+- `soundfile>=0.13,<0.14`: the pinned `SoundFile 0.10.2` wheel did not load `libsndfile` correctly on this machine
+
+Also note:
+
+- `torchaudio.save()` in the current PyTorch stack expects `torchcodec`
+- the headless generator script uses `soundfile.write()` instead, which avoids that extra dependency
+
+## Learning Map
+
+If you're new to ML tooling, the moving parts here are:
+
+1. Model weights
+   `Foundation_1.safetensors` is the learned parameter file.
+
+2. Model config
+   `model_config.json` describes the architecture and conditioning schema.
+
+3. Runtime
+   PyTorch loads the graph and executes it on `mps`, `cuda`, or `cpu`.
+
+4. Sampler
+   Diffusion models do not emit audio in one pass. They iteratively denoise random noise over multiple steps.
+
+5. Conditioning
+   Foundation-1 uses prompt text plus timing metadata like `seconds_total`.
+
+## Quality vs Speed
+
+- `steps=8` is only a smoke test
+- `steps=50-100` is a more realistic interactive range
+- higher step counts usually improve quality but increase latency
+
+## Recommended First Commands
+
+Open the UI:
+
+```bash
+source .venv/bin/activate
+python run_gradio.py
+```
+
+Run a custom prompt:
+
+```bash
+source .venv/bin/activate
+python scripts/generate_foundation1.py \
+  --prompt "Bass, Wavetable Bass, Acid, Gritty, 4 Bars, 140 BPM, F minor" \
+  --steps 12 \
+  --seconds-total 8 \
+  --output generations/bass-test.wav
+```

--- a/README.md
+++ b/README.md
@@ -1,199 +1,294 @@
+# RC Stable Audio Tools
 
-# 🎵 RC Stable Audio Tools
+RC Stable Audio Tools is RoyalCities' fork of Stability AI's `stable-audio-tools` project. It adds a friendlier Gradio workflow for model discovery, dynamic model loading, structured music prompting, automatic trimming, and optional sample-to-MIDI conversion.
 
-**Stable Audio Tools** provides training and inference tools for generative audio models from Stability AI. This repository is a fork with additional modifications to enhance functionality such as:
+If you are coming here for Foundation-1 specifically, this repo is a practical local runner for models like:
 
-- **Dynamic Model Loading**: Enables dynamic model swaps of the base model and any future community finetune releases.
+- `RoyalCities/Foundation-1`
+- `RoyalCities/RC_Infinite_Pianos`
+- `RoyalCities/Vocal_Textures_Main`
+- `adlb/Audialab_EDM_Elements`
 
-<p align="center">
-  <img src="https://i.imgur.com/kB8CQ3J.gif" alt="Model Loader Gif" width="50%">
-</p>
+It can be used in three ways:
 
+1. As a local Gradio UI for prompting and auditioning models.
+2. As a headless local generator from the command line.
+3. As the basis for an HTTP inference service you can deploy to a GPU provider.
 
-- **Random Prompt Button**: A one-click Random Prompt button tied directly onto the loaded models metadata.
+## What This Fork Adds
 
-<p align="center">
-  <img src="https://i.imgur.com/fNEE8cR.gif" alt="Random Prompt Button Gif" width="95%">
-</p>
+Compared with upstream `stable-audio-tools`, this fork focuses on usability:
 
+- Dynamic model loading from local checkpoints.
+- A Hugging Face downloader flow when `models/` is empty.
+- Prompt helpers tailored to music production workflows.
+- BPM, bar-count, and key controls wired into prompt conditioning.
+- Random prompt generation based on model metadata.
+- Automatic sample trimming to the requested musical grid length.
+- Automatic sample-to-MIDI conversion with Basic Pitch.
+- Apple Silicon support in the verified local setup path.
 
-- **BPM & Bar Selector**: BPM & Bar settings tied to the model's timing conditioning, which will auto-fill any prompt with the needed BPM/Bar info. You can also lock or unlock the BPM if you wish to randomize this as well with the Random Prompt button.
+Examples from the current UI:
 
-<p align="center">
-  <img src="https://i.imgur.com/hcedPl5.png" alt="BPM and Bar Example Gif" width="50%">
-</p>
+- Dynamic model loading
 
-- **Key Signature Locking**: Key signature is now tied to UI and can be locked or unlocked with the random prompt button.
+  <p align="center">
+    <img src="https://i.imgur.com/kB8CQ3J.gif" alt="Dynamic model loading" width="50%">
+  </p>
 
-<p align="center">
-  <img src="https://i.imgur.com/7IXXDSZ.jpeg" alt="Key Signature Image" width="50%">
-</p>
+- Random prompt generation
 
-- **Automatic Sample to MIDI Converter**: The fork will automatically convert all generated samples to .MID format, enabling users to have an infinite source of MIDI.
+  <p align="center">
+    <img src="https://i.imgur.com/fNEE8cR.gif" alt="Random prompt generation" width="95%">
+  </p>
 
-<p align="center">
-  <img src="https://i.imgur.com/R9ipGiq.gif" alt="Midi Converter Example Gif" width="50%">
-</p>
+- BPM and bar-aware prompting
 
-- **Automatic Sample Trimming**: The fork will automatically trim all generated samples to the exact length desired for easier importing into DAWs.
+  <p align="center">
+    <img src="https://i.imgur.com/hcedPl5.png" alt="BPM and bar controls" width="50%">
+  </p>
 
-<p align="center">
-  <img src="https://i.imgur.com/ApH5SOM.gif" alt="Midi Converter Example Gif" width="75%">
-</p>
+- Key locking
 
-## 🚀 Installation
+  <p align="center">
+    <img src="https://i.imgur.com/7IXXDSZ.jpeg" alt="Key locking" width="50%">
+  </p>
 
-### 📥 Clone the Repository
+- MIDI conversion
 
-First, clone the repository to your local machine:
+  <p align="center">
+    <img src="https://i.imgur.com/R9ipGiq.gif" alt="MIDI conversion" width="50%">
+  </p>
+
+- Automatic trimming
+
+  <p align="center">
+    <img src="https://i.imgur.com/ApH5SOM.gif" alt="Automatic trimming" width="75%">
+  </p>
+
+## How It Works
+
+At a high level, the generation pipeline is:
+
+1. Pick a model checkpoint and matching `model_config.json`.
+2. Convert your musical intent into conditioning inputs.
+   - prompt text
+   - bar count
+   - BPM
+   - key / scale
+   - optional negative prompt
+3. Run diffusion sampling for a chosen number of steps.
+4. Decode latent audio back into waveform audio.
+5. Trim to the requested musical duration.
+6. Save a WAV file.
+7. Optionally run Basic Pitch to create a MIDI file and preview piano roll.
+
+The most important files for that flow are:
+
+- `run_gradio.py`: launches the web UI.
+- `stable_audio_tools/interface/gradio.py`: model loading, prompting, generation, and post-processing.
+- `scripts/generate_foundation1.py`: simple headless generation example.
+- `deploy/api_server.py`: minimal HTTP inference server for hosted deployments.
+- `config.json`: model locations, output locations, and pre-listed Hugging Face repos.
+
+## Quick Start
+
+### 1. Clone the repo
 
 ```bash
 git clone https://github.com/RoyalCities/RC-stable-audio-tools.git
 cd RC-stable-audio-tools
 ```
 
-### 🔧 Setup the Environment 
+### 2. Use Python 3.10
 
-#### ✅ Python Version (Important)
+This project still depends on older pinned packages. Python `3.10` is the safest choice.
 
-Use **Python 3.10**. Newer versions (e.g. 3.11+) can fail dependency resolution due to pinned packages (notably older SciPy wheels).
+### 3. Install and download a model
 
-#### 🌐 Create a Virtual Environment
+### macOS / Apple Silicon
 
-It's recommended to use a virtual environment to manage dependencies:
-
-- **Windows:**
-
-  ```bash
-  python -m venv venv
-  venv\Scripts\activate
-  ```
-
-- **macOS and Linux:**
-
-  ```bash
-  python3 -m venv venv
-  source venv/bin/activate
-  ```
-
-#### 📦 Install the Required Packages
-
-Install Stable Audio Tools and the necessary packages from `setup.py`:
+This is the most verified path in this repo right now:
 
 ```bash
-pip install stable-audio-tools
+chmod +x scripts/setup_foundation1_macos.sh
+./scripts/setup_foundation1_macos.sh
+```
+
+That script:
+
+- creates `.venv`
+- installs PyTorch
+- installs this repo
+- applies the compatibility fixes needed on macOS
+- downloads `RoyalCities/Foundation-1`
+
+More detail lives in [LOCAL_MAC_SETUP.md](LOCAL_MAC_SETUP.md).
+
+### Windows / Linux
+
+The original workflow still applies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -U pip wheel
 pip install .
 ```
 
-### 🪟 Additional Step for Windows Users
+If you are on NVIDIA hardware, install the matching CUDA build of PyTorch for your system. On Windows and Linux, optional TorchAO INT4 inference is also supported when the environment is compatible.
 
-To ensure Gradio uses GPU/CUDA and not default to CPU, uninstall and reinstall `torch`, `torchvision`, and `torchaudio` with the correct CUDA version:
+## Running The UI
 
-```bash
-pip uninstall -y torch torchvision torchaudio
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu121
-```
-
-### 🧪 Optional (Windows / Linux): INT4 / Low-VRAM Mode (TorchAO)
-
-This fork supports **optional** INT4 weight-only inference via TorchAO.  
-It can reduce VRAM usage further, but it can be **very slow on Windows** because Triton fast-kernels are usually unavailable (falls back to slower paths). 
-
-To enable the INT4 toggle in the UI:
-
-**Windows (recommended, pinned):**
-```bash
-pip install torchao==0.12.0
-```
-
-**Linux:**
-```bash
-pip install torchao
-```
-
-⚠️ On Linux, using the unpinned version may require some tweaking depending on your CUDA, PyTorch, and driver versions. 
-
-If TorchAO isn’t installed or compatible with your environment, the INT4 toggle will remain hidden/disabled.
-
-## ⚙️ Configuration
-
-A sample `config.json` is included in the root directory. Customize it to specify directories for custom models and outputs (.wav and .mid files will be stored here):
-
-```json
-{
-    "model_directory": "models",
-    "output_directory": "generations"
-}
-```
-
-## 🖥️ Usage
-
-### 🎚️ Running the Gradio Interface
-
-Start the Gradio interface using a batch file or directly from the command line:
-
-#### Batch file example
-
-```batch
-@echo off
-cd /d path-to-your-venv/Scripts
-call activate
-cd /d path-to-your-stable-audio-tools
-python run_gradio.py --model-config models/path-to-config/example_config.json --ckpt-path models/path-to-config/example.ckpt
-pause
-```
-
-#### Basic command line example
-
-You can launch the web UI by simply calling:
+With the environment active:
 
 ```bash
+source .venv/bin/activate
 python run_gradio.py
 ```
 
-This will start the gradio UI. If you're running for the first time, it will launch a model downloader interface, where you can initialize the app by downloading your first model. After downloading, you will need to restart the app to get the full UI.
+The first launch behaves like this:
 
-When you run the app AFTER downloading a model, the full UI will launch.
+1. If `models/` is empty, you get a Hugging Face downloader UI.
+2. Download a model such as `RoyalCities/Foundation-1`.
+3. Restart `python run_gradio.py`.
+4. The full generation UI appears.
 
-
-#### Custom command line example
-
-You can also launch the app with custom flags:
+If you already have a local checkpoint and config, you can also pass them directly:
 
 ```bash
-python run_gradio.py --model-config models/path-to-config/example_config.json --ckpt-path models/path-to-config/example.ckpt
+python run_gradio.py \
+  --model-config models/Foundation-1/model_config.json \
+  --ckpt-path models/Foundation-1/Foundation_1.safetensors
 ```
 
-### 🎶 Generating Audio and MIDI
+## Using The UI Well
 
-Input prompts in the Gradio interface to generate audio and MIDI files, which will be saved as specified in `config.json`.
+The UI is built around musical structure, not just abstract text prompts.
 
-The interface has been expanded with Bar/BPM settings (which modifies both the user prompt + sample length conditioning), MIDI display + conversion and also features Dynamic Model Loading. 
+A strong prompt usually combines:
 
-Models must be stored inside their own sub folder along with their accompanying config files. i.e. A single finetune could have multiple checkpoints. All related checkpoints could go inside of the same "model1" subfolder but its important their associated config file is included within the same folder as the checkpoint itself.
+- source or family
+- timbre
+- musical behavior
+- bars
+- BPM
+- key / scale
 
-To switch models simply pick the model you want to load using the drop down and pick "Load Model". 
+Example:
 
-### 🤗 Downloading models from HuggingFace
+```text
+Bass, Wavetable Bass, Acid, Gritty, 4 Bars, 140 BPM, F minor
+```
 
-![hffs.gif](hffs.gif)
+Practical notes:
 
-When you launch with `python run_gradio.py`, it will:
+- Low step counts are good for smoke tests.
+- `50-100` steps is a more realistic interactive range.
+- Higher step counts improve quality at the cost of latency.
+- Different models respond differently to prompt density, so start simple and add detail gradually.
 
-1. First check if the `models` folder has any model downloaded.
-2. If there is a model, it will launch the full UI with that model loaded.
-3. If the models folder is empty, it will launch a HFFS (HuggingFace downloader) UI, where you can either select from the preset models, or enter any HuggingFace repo id to download. (After downloading a model, you will need to restart the app to launch the full UI).
-4. To customize the preset models that appear in the downloader dropdown, edit the `config.json` file to add more entries to the `hffs[0].options` array.
+## Headless Usage
 
-## 🛠️ Advanced Usage
+If you want a reproducible local command instead of the UI:
 
-For detailed instructions on training and inference commands, flags, and additional options, refer to the main GitHub documentation:
-[Stable Audio Tools Detailed Usage](https://github.com/Stability-AI/stable-audio-tools)
+```bash
+source .venv/bin/activate
+python scripts/generate_foundation1.py \
+  --prompt "Bass, Wavetable Bass, Acid, Gritty, 4 Bars, 140 BPM, F minor" \
+  --steps 12 \
+  --seconds-total 8 \
+  --output generations/bass-test.wav
+```
 
----
+This is the simplest way to understand the core inference flow without thinking about the Gradio layer.
 
-~~I did my best to make sure the code is OS agnostic but I've only been able to test this with Windows / NVIDIA. Hopefully it works for other operating systems.~~ The project now fully supports macOS and Apple Silicon (M1 and above). Special thanks to [@cocktailpeanut](https://github.com/cocktailpeanut) for their help!
+## Deploying As An API
 
-If theres any other features or tooling that you may want let me know on here or by contacting me on [Twitter](https://x.com/RoyalCities). I'm just a hobbyist but if it can be done I'll see what I can do.
+This repo now includes a small FastAPI server:
 
-Have fun!
+```bash
+source .venv/bin/activate
+uvicorn deploy.api_server:app --host 0.0.0.0 --port 8000
+```
+
+It exposes:
+
+- `GET /health`
+- `POST /generate`
+
+That is the shape most hosted model deployments take: load the model once, keep it warm on a GPU, and send prompt requests to an HTTP endpoint.
+
+More detail and provider notes live in [DEPLOYMENT_NOTES.md](DEPLOYMENT_NOTES.md).
+
+## Which Hosted Option Fits What
+
+If you are new to model deployment, the terms you are looking for are usually:
+
+- inference endpoint
+- model hosting
+- inference server
+
+The practical options are:
+
+- Hugging Face Spaces
+  - best for a public demo UI
+- Hugging Face Inference Endpoints
+  - best for a managed hosted API
+- Modal
+  - best for a Python-first deployment workflow
+- RunPod
+  - best when you want more direct control over GPU infrastructure
+
+## Model Layout
+
+Models should live in their own subdirectory inside `models/`, alongside the matching config file.
+
+For example:
+
+```text
+models/
+  Foundation-1/
+    Foundation_1.safetensors
+    model_config.json
+```
+
+This is what lets the UI discover checkpoints and offer dynamic model switching.
+
+## Repository Layout
+
+Useful entry points:
+
+- `run_gradio.py`
+- `config.json`
+- `models/`
+- `generations/`
+- `scripts/setup_foundation1_macos.sh`
+- `scripts/generate_foundation1.py`
+- `deploy/api_server.py`
+- `LOCAL_MAC_SETUP.md`
+- `DEPLOYMENT_NOTES.md`
+
+## Known Notes
+
+- Python `3.10` is recommended.
+- On current PyTorch builds, `torchaudio.save()` may expect `torchcodec`.
+- This repo's verified local path uses `soundfile` for output writing instead.
+- You will still see some dependency warnings from older transitive packages. They are noisy, but they do not block generation in the verified path.
+
+## Credits
+
+This project stands on a lot of upstream work:
+
+- Stability AI for the original [`stable-audio-tools`](https://github.com/Stability-AI/stable-audio-tools)
+- RoyalCities for this fork and the Foundation-1 ecosystem
+- [@cocktailpeanut](https://github.com/cocktailpeanut) for Apple Silicon support help
+- Hugging Face for model distribution and hosting infrastructure
+- Descript's [Basic Pitch](https://github.com/spotify/basic-pitch) for the MIDI conversion workflow
+- PyTorch, torchaudio, Gradio, k-diffusion, x-transformers, and the rest of the open-source stack this repo builds on
+
+If you use a model from Hugging Face, check that model's own card and license as well. For example, `RoyalCities/Foundation-1` is based on `stabilityai/stable-audio-open-1.0` and carries its own model-card and license context.
+
+## Acknowledgement
+
+This repo is maintained as a practical, creator-friendly layer on top of a powerful but fairly technical audio generation stack. The goal is simple: make it easier to load a model, prompt it musically, generate something useful, and move quickly.

--- a/deploy/api_server.py
+++ b/deploy/api_server.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import soundfile as sf
+import torch
+from einops import rearrange
+from fastapi import FastAPI, HTTPException, Response
+from pydantic import BaseModel, Field
+
+from stable_audio_tools.interface.gradio import load_model, pick_preferred_dtype
+from stable_audio_tools.inference.generation import generate_diffusion_cond
+
+
+MODEL = None
+MODEL_CONFIG = None
+DEVICE = None
+
+
+class GenerateRequest(BaseModel):
+    prompt: str = Field(..., min_length=1, description="Foundation-1 prompt text.")
+    seconds_total: int = Field(default=8, ge=1, le=30)
+    steps: int = Field(default=12, ge=1, le=250)
+    cfg_scale: float = Field(default=7.0, ge=0.0, le=25.0)
+    seed: int = Field(default=42)
+    sampler_type: str = Field(default="dpmpp-2m-sde")
+    sigma_min: float = Field(default=0.3, gt=0.0)
+    sigma_max: float = Field(default=50.0, gt=0.0)
+    rho: float = Field(default=1.0, gt=0.0)
+
+
+def pick_device() -> torch.device:
+    forced = os.environ.get("FOUNDATION1_DEVICE")
+    if forced:
+        return torch.device(forced)
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def model_paths() -> tuple[Path, Path]:
+    model_dir = Path(os.environ.get("FOUNDATION1_MODEL_DIR", "models/Foundation-1"))
+    config_path = model_dir / "model_config.json"
+    ckpt_path = model_dir / "Foundation_1.safetensors"
+    return config_path, ckpt_path
+
+
+def load_runtime() -> None:
+    global MODEL, MODEL_CONFIG, DEVICE
+
+    config_path, ckpt_path = model_paths()
+    if not config_path.exists() or not ckpt_path.exists():
+        raise FileNotFoundError(
+            f"Expected {config_path} and {ckpt_path}. Download the model before starting the API."
+        )
+
+    with config_path.open() as f:
+        MODEL_CONFIG = json.load(f)
+
+    DEVICE = pick_device()
+    dtype = pick_preferred_dtype(DEVICE)
+    MODEL, _ = load_model(
+        model_config=MODEL_CONFIG,
+        model_ckpt_path=str(ckpt_path),
+        device=DEVICE,
+        preferred_dtype=dtype,
+    )
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    load_runtime()
+    yield
+
+
+app = FastAPI(title="Foundation-1 API", version="0.1.0", lifespan=lifespan)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    if MODEL is None or MODEL_CONFIG is None or DEVICE is None:
+        raise HTTPException(status_code=503, detail="Model is not loaded.")
+    return {
+        "status": "ok",
+        "device": DEVICE.type,
+        "sample_rate": str(MODEL_CONFIG["sample_rate"]),
+    }
+
+
+@app.post("/generate")
+def generate(req: GenerateRequest) -> Response:
+    if MODEL is None or MODEL_CONFIG is None or DEVICE is None:
+        raise HTTPException(status_code=503, detail="Model is not loaded.")
+
+    conditioning = [
+        {
+            "prompt": req.prompt,
+            "seconds_start": 0,
+            "seconds_total": req.seconds_total,
+        }
+    ]
+
+    audio = generate_diffusion_cond(
+        model=MODEL,
+        conditioning=conditioning,
+        steps=req.steps,
+        cfg_scale=req.cfg_scale,
+        batch_size=1,
+        sample_size=MODEL_CONFIG["sample_size"],
+        seed=req.seed,
+        device=DEVICE,
+        sampler_type=req.sampler_type,
+        sigma_min=req.sigma_min,
+        sigma_max=req.sigma_max,
+        rho=req.rho,
+    )
+
+    audio = audio[:, :, : MODEL_CONFIG["sample_rate"] * req.seconds_total]
+    audio = rearrange(audio, "b d n -> (b n) d")
+    audio = audio.to(torch.float32)
+    audio = audio.div(torch.max(torch.abs(audio))).clamp(-1, 1).cpu().numpy()
+
+    buffer = io.BytesIO()
+    sf.write(buffer, audio, MODEL_CONFIG["sample_rate"], format="WAV")
+    headers = {
+        "X-Foundation1-Device": DEVICE.type,
+        "X-Foundation1-Sample-Rate": str(MODEL_CONFIG["sample_rate"]),
+        "X-Foundation1-Seconds": str(req.seconds_total),
+    }
+    return Response(content=buffer.getvalue(), media_type="audio/wav", headers=headers)

--- a/scripts/generate_foundation1.py
+++ b/scripts/generate_foundation1.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+
+import soundfile as sf
+import torch
+from einops import rearrange
+
+from stable_audio_tools.interface.gradio import load_model, pick_preferred_dtype
+from stable_audio_tools.inference.generation import generate_diffusion_cond
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a short Foundation-1 sample locally.")
+    parser.add_argument(
+        "--model-dir",
+        default="models/Foundation-1",
+        help="Directory containing Foundation_1.safetensors and model_config.json.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="Synth Pad, Warm, Airy, Chord Progression, 4 Bars, 120 BPM, D minor",
+        help="Prompt sent to the model.",
+    )
+    parser.add_argument(
+        "--seconds-total",
+        type=int,
+        default=8,
+        help="Conditioning length in seconds.",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=8,
+        help="Sampling steps. Low values are good for smoke tests; higher values improve quality.",
+    )
+    parser.add_argument(
+        "--cfg-scale",
+        type=float,
+        default=7.0,
+        help="Classifier-free guidance strength.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Seed for repeatable output.",
+    )
+    parser.add_argument(
+        "--output",
+        default="generations/foundation1-smoketest.wav",
+        help="Where to write the generated WAV.",
+    )
+    return parser.parse_args()
+
+
+def pick_device() -> torch.device:
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("cpu")
+
+
+def main() -> None:
+    args = parse_args()
+    model_dir = Path(args.model_dir)
+    config_path = model_dir / "model_config.json"
+    ckpt_path = model_dir / "Foundation_1.safetensors"
+
+    if not config_path.exists() or not ckpt_path.exists():
+        raise FileNotFoundError(
+            f"Expected both {config_path} and {ckpt_path}. Run scripts/setup_foundation1_macos.sh first."
+        )
+
+    with config_path.open() as f:
+        cfg = json.load(f)
+
+    device = pick_device()
+    dtype = pick_preferred_dtype(device)
+    print(f"Using device={device} dtype={dtype}")
+
+    model, _ = load_model(
+        model_config=cfg,
+        model_ckpt_path=str(ckpt_path),
+        device=device,
+        preferred_dtype=dtype,
+    )
+
+    conditioning = [
+        {
+            "prompt": args.prompt,
+            "seconds_start": 0,
+            "seconds_total": args.seconds_total,
+        }
+    ]
+
+    audio = generate_diffusion_cond(
+        model=model,
+        conditioning=conditioning,
+        steps=args.steps,
+        cfg_scale=args.cfg_scale,
+        batch_size=1,
+        sample_size=cfg["sample_size"],
+        seed=args.seed,
+        device=device,
+        sampler_type="dpmpp-2m-sde",
+        sigma_min=0.3,
+        sigma_max=50,
+        rho=1.0,
+    )
+
+    audio = audio[:, :, : cfg["sample_rate"] * args.seconds_total]
+    audio = rearrange(audio, "b d n -> (b n) d")
+    audio = audio.to(torch.float32)
+    audio = audio.div(torch.max(torch.abs(audio))).clamp(-1, 1).cpu().numpy()
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(output_path, audio, cfg["sample_rate"])
+    print(f"Saved {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_foundation1_macos.sh
+++ b/scripts/setup_foundation1_macos.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="${PYTHON_BIN:-python3.10}"
+VENV_DIR="${VENV_DIR:-.venv}"
+MODEL_REPO="${MODEL_REPO:-RoyalCities/Foundation-1}"
+MODEL_DIR="${MODEL_DIR:-models/Foundation-1}"
+export MODEL_REPO MODEL_DIR
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "Missing $PYTHON_BIN. Install Python 3.10 first."
+  exit 1
+fi
+
+"$PYTHON_BIN" -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
+
+python -m pip install -U pip wheel
+python -m pip install 'setuptools<81'
+python -m pip install torch torchvision torchaudio
+python -m pip install .
+python -m pip install 'soundfile>=0.13,<0.14'
+
+mkdir -p "$MODEL_DIR"
+python - <<'PY'
+from huggingface_hub import hf_hub_download
+from pathlib import Path
+import os
+
+repo = os.environ["MODEL_REPO"]
+out = Path(os.environ["MODEL_DIR"])
+out.mkdir(parents=True, exist_ok=True)
+
+for filename in ("Foundation_1.safetensors", "model_config.json"):
+    path = hf_hub_download(repo_id=repo, filename=filename, local_dir=str(out))
+    print(f"downloaded {path}")
+PY
+
+cat <<'EOF'
+
+Setup complete.
+
+Next steps:
+  1. source .venv/bin/activate
+  2. python run_gradio.py
+  3. Or run a headless smoke test:
+     python scripts/generate_foundation1.py
+
+EOF

--- a/stable_audio_tools/interface/gradio.py
+++ b/stable_audio_tools/interface/gradio.py
@@ -11,6 +11,7 @@ import random
 import hffs
 import math
 import re
+import soundfile as sf
 
 
 
@@ -88,6 +89,22 @@ current_prompt_generator = master_prompt_map.default_prompt_generator
 
 # Ensure the output directory exists
 os.makedirs(output_directory, exist_ok=True)
+
+
+def save_audio_file(file_path: str, audio: torch.Tensor, sample_rate: int) -> None:
+    """Write audio without requiring torchcodec-backed torchaudio.save()."""
+    if not isinstance(audio, torch.Tensor):
+        raise TypeError(f"Expected a torch.Tensor, got {type(audio)!r}")
+
+    audio = audio.detach().cpu()
+    if audio.ndim == 1:
+        audio = audio.unsqueeze(0)
+    if audio.ndim != 2:
+        raise ValueError(f"Expected audio with shape [channels, samples], got {tuple(audio.shape)}")
+
+    audio_np = audio.transpose(0, 1).contiguous().numpy()
+    subtype = "PCM_16" if audio_np.dtype == np.int16 else None
+    sf.write(file_path, audio_np, sample_rate, subtype=subtype)
 
 def pick_preferred_dtype(device: torch.device) -> torch.dtype:
     """
@@ -372,6 +389,9 @@ def convert_audio_to_midi(audio_path, output_dir):
 def plot_piano_roll(pm, start_pitch, end_pitch, fs=100):
     plt.figure(figsize=(12, 6))
     piano_roll = pm.get_piano_roll(fs=fs)[start_pitch:end_pitch]
+    if piano_roll.size == 0 or piano_roll.shape[1] == 0:
+        plt.close()
+        return None
     librosa.display.specshow(piano_roll, hop_length=1, sr=fs, x_axis='time', y_axis='cqt_note',
                              fmin=pretty_midi.note_number_to_hz(start_pitch))
     plt.colorbar(format='%+2.0f dB')
@@ -577,7 +597,7 @@ def generate_cond(
     base_name = amended_prompt.replace(" ", "_").replace(",", "").replace(":", "").replace(";", "")
     file_path = get_unique_filename(base_name, seed, output_directory)
 
-    torchaudio.save(file_path, wav_i16, sample_rate)
+    save_audio_file(file_path, wav_i16, sample_rate)
 
     # ---------- MIDI conversion ----------
     try:
@@ -596,13 +616,16 @@ def generate_cond(
         if midi_output_path is not None:
             midi_data = pretty_midi.PrettyMIDI(midi_output_path)
             print("MIDI file loaded successfully.")
-            piano_roll_path = plot_piano_roll(midi_data, 21, 109)
+            try:
+                piano_roll_path = plot_piano_roll(midi_data, 21, 109)
+            except Exception as e:
+                print(f"Piano roll preview failed: {e}")
+                piano_roll_path = None
         else:
             piano_roll_path = None
 
     except Exception as e:
         print(f"An error occurred during MIDI conversion: {e}")
-        midi_output_path = None
         piano_roll_path = None
 
     if torch.cuda.is_available():
@@ -1187,7 +1210,7 @@ def autoencoder_process(audio, latent_noise, n_quantizers):
 
     audio = audio.to(torch.float32).clamp(-1, 1).mul(32767).to(torch.int16).cpu()
 
-    torchaudio.save("output.wav", audio, sample_rate)
+    save_audio_file("output.wav", audio, sample_rate)
 
     return "output.wav"
 
@@ -1236,7 +1259,7 @@ def diffusion_prior_process(audio, steps, sampler_type, sigma_min, sigma_max):
 
     audio = audio.to(torch.float32).div(torch.max(torch.abs(audio))).clamp(-1, 1).mul(32767).to(torch.int16).cpu()
 
-    torchaudio.save("output.wav", audio, sample_rate)
+    save_audio_file("output.wav", audio, sample_rate)
 
     return "output.wav"
 

--- a/stable_audio_tools/interface/interfaces/diffusion_cond.py
+++ b/stable_audio_tools/interface/interfaces/diffusion_cond.py
@@ -8,6 +8,7 @@ import torch
 import torchaudio
 import threading 
 import os, time, math
+import soundfile as sf
 
 from einops import rearrange
 from torchaudio import transforms as T
@@ -21,6 +22,21 @@ sample_size = 2097152
 sample_rate = 44100
 model_half = True
 diffusion_objective = None
+
+
+def save_audio_file(file_path, audio, sample_rate):
+    if not isinstance(audio, torch.Tensor):
+        raise TypeError(f"Expected a torch.Tensor, got {type(audio)!r}")
+
+    audio = audio.detach().cpu()
+    if audio.ndim == 1:
+        audio = audio.unsqueeze(0)
+    if audio.ndim != 2:
+        raise ValueError(f"Expected audio with shape [channels, samples], got {tuple(audio.shape)}")
+
+    audio_np = audio.transpose(0, 1).contiguous().numpy()
+    subtype = "PCM_16" if audio_np.dtype == np.int16 else None
+    sf.write(file_path, audio_np, sample_rate, subtype=subtype)
 
 # when using a prompt in a filename
 def condense_prompt(prompt):
@@ -256,7 +272,7 @@ def generate_cond(
     audio = audio.to(torch.float32).div(torch.max(torch.abs(audio))).clamp(-1, 1).mul(32767).to(torch.int16).cpu()
 
     # save as wav file
-    torchaudio.save(output_wav, audio, sample_rate)
+    save_audio_file(output_wav, audio, sample_rate)
 
     # If file_format is other than wav, convert to other file format
     cmd = ""


### PR DESCRIPTION
## Summary
- rewrite the README around what the project is, how it works, and how to use it
- add a verified macOS setup guide, a headless generation script, and deployment notes
- fix local UI audio saving on current torchaudio builds by writing WAV output with soundfile

## Validation
- launched the Gradio UI locally on Apple Silicon
- generated audio from the Gradio generation path after the save fix
- generated audio with the headless script
- started the FastAPI inference server and verified 
